### PR TITLE
PIL-2131 Update accessibility-assessment.json to exclude account management spinners

### DIFF
--- a/accessibility-assessment.json
+++ b/accessibility-assessment.json
@@ -11,6 +11,14 @@
     {
       "path": "/report-pillar2-top-up-taxes/review-submit/processing-registration",
       "reason": "Implementation of spinner page with polling"
+    },
+    {
+      "path": "/report-pillar2-top-up-taxes/manage-account/contact/waiting-room",
+      "reason": "Implementation of spinner page with polling"
+    },
+    {
+      "path": "/report-pillar2-top-up-taxes/manage-account/details/waiting-room",
+      "reason": "Implementation of spinner page with polling"
     }
   ]
 }


### PR DESCRIPTION
Like the other spinners we will exclude these from the accessibility report.

If we were to make a generic waiting room we would only need to add one page to these exclusions. We have raised [PIL-2196](https://jira.tools.tax.service.gov.uk/browse/PIL-2196) to do this.