### PR TITLE
Content checks removed from files

### DIFF
--- a/src/test/resources/features/ContactDetailsAndRegistration.feature
+++ b/src/test/resources/features/ContactDetailsAndRegistration.feature
@@ -407,12 +407,8 @@ Feature: Contact details for the filing member
     And I click on Save&Continue button
     Then I should be redirect to Registration processing page
     Then I should navigate to Registration confirmation page
-    And The Body content should be Test Example Company Name has successfully registered to report for Domestic Top-up Tax
     And I click the browser back button
     Then I should navigate to Registration return error page
-    And The Heading should be You cannot return, your registration is complete
-    And The Body content should be You have successfully registered to report Pillar 2 Top-up Taxes.
-    And The Body content should be You can now report and manage your Pillar 2 Top-up Taxes.
     And I click report and manage your Pillar 2 Top-up Taxes. link
     And I should be on Dashboard page
     And I click the browser back button

--- a/src/test/resources/features/DashboardPage.feature
+++ b/src/test/resources/features/DashboardPage.feature
@@ -7,35 +7,14 @@ Feature: Dashboard Page
   Scenario: 1 - User navigates to Dashboard page and validates the links
     Given Organisation User logs in with existing entity group HMRC-PILLAR2-ORG, PLRID and XMPLR0012345674 for Pillar2 service
     Then I should be on Dashboard page
-#    ------------------DashboardViewSpec
-#    And The Heading should be Your Pillar 2 Top-up Taxes account
-#    ---------------
     When I click Refer to the Pillar 2 Top-up Taxes manual (opens in new tab) link
     Then I should be navigated to new tab
     And  I should be on Draft guidance page
     Then I close new tab
     And I should navigate back to main tab
     And I should be on Dashboard page
-#    -----------------DashboardViewSpec
-#    And I should see User details in dashboard page
-#    And I should see user details row 1 key Group’s Pillar 2 Top-up Taxes ID:
-#    And I should see user details row 2 key Registration date:
-#    And I should see user details row 3 key Ultimate Parent Entity:
-#    And I should see the heading 1 on Dashboard page as Payments
-#    And The Body content should be You have no payments due
-#    And The Body content should be Make a payment
-#    And I should see the heading 2 on Dashboard page as Manage your account
-#    And The Body content should be View and amend contact details
-#    And The Body content should be View and amend group details
-#    And The Body content should be HMRC are currently delivering this service on a phased approach. We’ll release the tools that you need to submit your returns before the due date for reporting.
-#    And The Body content should be Refer to the Pillar 2 Top-up Taxes manual (opens in new tab) for more details.
-#    -------------------
     When I click Make a payment link
     Then I should navigate to Make a payment page
-#---------------------MakeAPaymentDashboardViewSpec
-#    And The Body content should be Your unique payment reference is XMPLR0012345674. You must use this when making Pillar 2 Top-up Taxes payments.
-#    And The Body content should be You can use the 'Pay Now' button to pay online, or read more about other payment methods. (opens in a new tab)
-#    --------------------
     When I click Report Pillar 2 Top-up Taxes link
     Then I should be on Dashboard page
     When I click Make a payment link
@@ -63,17 +42,6 @@ Feature: Dashboard Page
   Scenario: 2 - User navigates to group details page and validates the data
     Given Organisation User logs in with existing entity group HMRC-PILLAR2-ORG, PLRID and XMPLR0012345676 for Pillar2 service
     Then I should be on Dashboard page
-   #    -----------------DashboardViewSpec
-#    And I should see User details in dashboard page
-#    And I should see user details row 1 key Group’s Pillar 2 Top-up Taxes ID:
-#    And I should see user details row 2 key Registration date:
-#    And I should see user details row 3 key Ultimate Parent Entity:
-#    And I should see user details row 1 value XMPLR0012345676
-#    And I should see user details row 2 value 31 January 2024
-#    And I should see user details row 3 value International Organisation Inc.
-#    And I should see the heading 1 on Dashboard page as Payments
-#    And I should see the heading 2 on Dashboard page as Manage your account
-    #    -----------------
     When I click View and amend group details link
     Then I should navigate to accounts summary page
     And the page title should be Group details - Report Pillar 2 Top-up Taxes - GOV.UK

--- a/src/test/resources/features/DashboardPage.feature
+++ b/src/test/resources/features/DashboardPage.feature
@@ -7,29 +7,35 @@ Feature: Dashboard Page
   Scenario: 1 - User navigates to Dashboard page and validates the links
     Given Organisation User logs in with existing entity group HMRC-PILLAR2-ORG, PLRID and XMPLR0012345674 for Pillar2 service
     Then I should be on Dashboard page
-    And The Heading should be Your Pillar 2 Top-up Taxes account
+#    ------------------DashboardViewSpec
+#    And The Heading should be Your Pillar 2 Top-up Taxes account
+#    ---------------
     When I click Refer to the Pillar 2 Top-up Taxes manual (opens in new tab) link
     Then I should be navigated to new tab
     And  I should be on Draft guidance page
     Then I close new tab
     And I should navigate back to main tab
     And I should be on Dashboard page
-    And I should see User details in dashboard page
-    And I should see user details row 1 key Group’s Pillar 2 Top-up Taxes ID:
-    And I should see user details row 2 key Registration date:
-    And I should see user details row 3 key Ultimate Parent Entity:
-    And I should see the heading 1 on Dashboard page as Payments
-    And The Body content should be You have no payments due
-    And The Body content should be Make a payment
-    And I should see the heading 2 on Dashboard page as Manage your account
-    And The Body content should be View and amend contact details
-    And The Body content should be View and amend group details
-    And The Body content should be HMRC are currently delivering this service on a phased approach. We’ll release the tools that you need to submit your returns before the due date for reporting.
-    And The Body content should be Refer to the Pillar 2 Top-up Taxes manual (opens in new tab) for more details.
+#    -----------------DashboardViewSpec
+#    And I should see User details in dashboard page
+#    And I should see user details row 1 key Group’s Pillar 2 Top-up Taxes ID:
+#    And I should see user details row 2 key Registration date:
+#    And I should see user details row 3 key Ultimate Parent Entity:
+#    And I should see the heading 1 on Dashboard page as Payments
+#    And The Body content should be You have no payments due
+#    And The Body content should be Make a payment
+#    And I should see the heading 2 on Dashboard page as Manage your account
+#    And The Body content should be View and amend contact details
+#    And The Body content should be View and amend group details
+#    And The Body content should be HMRC are currently delivering this service on a phased approach. We’ll release the tools that you need to submit your returns before the due date for reporting.
+#    And The Body content should be Refer to the Pillar 2 Top-up Taxes manual (opens in new tab) for more details.
+#    -------------------
     When I click Make a payment link
     Then I should navigate to Make a payment page
-    And The Body content should be Your unique payment reference is XMPLR0012345674. You must use this when making Pillar 2 Top-up Taxes payments.
-    And The Body content should be You can use the 'Pay Now' button to pay online, or read more about other payment methods. (opens in a new tab)
+#---------------------MakeAPaymentDashboardViewSpec
+#    And The Body content should be Your unique payment reference is XMPLR0012345674. You must use this when making Pillar 2 Top-up Taxes payments.
+#    And The Body content should be You can use the 'Pay Now' button to pay online, or read more about other payment methods. (opens in a new tab)
+#    --------------------
     When I click Report Pillar 2 Top-up Taxes link
     Then I should be on Dashboard page
     When I click Make a payment link
@@ -57,15 +63,17 @@ Feature: Dashboard Page
   Scenario: 2 - User navigates to group details page and validates the data
     Given Organisation User logs in with existing entity group HMRC-PILLAR2-ORG, PLRID and XMPLR0012345676 for Pillar2 service
     Then I should be on Dashboard page
-    And I should see User details in dashboard page
-    And I should see user details row 1 key Group’s Pillar 2 Top-up Taxes ID:
-    And I should see user details row 2 key Registration date:
-    And I should see user details row 3 key Ultimate Parent Entity:
-    And I should see user details row 1 value XMPLR0012345676
-    And I should see user details row 2 value 31 January 2024
-    And I should see user details row 3 value International Organisation Inc.
-    And I should see the heading 1 on Dashboard page as Payments
-    And I should see the heading 2 on Dashboard page as Manage your account
+   #    -----------------DashboardViewSpec
+#    And I should see User details in dashboard page
+#    And I should see user details row 1 key Group’s Pillar 2 Top-up Taxes ID:
+#    And I should see user details row 2 key Registration date:
+#    And I should see user details row 3 key Ultimate Parent Entity:
+#    And I should see user details row 1 value XMPLR0012345676
+#    And I should see user details row 2 value 31 January 2024
+#    And I should see user details row 3 value International Organisation Inc.
+#    And I should see the heading 1 on Dashboard page as Payments
+#    And I should see the heading 2 on Dashboard page as Manage your account
+    #    -----------------
     When I click View and amend group details link
     Then I should navigate to accounts summary page
     And the page title should be Group details - Report Pillar 2 Top-up Taxes - GOV.UK

--- a/src/test/resources/features/DifferentAffinityKBPage.feature
+++ b/src/test/resources/features/DifferentAffinityKBPage.feature
@@ -5,10 +5,6 @@ Feature: Failure scenarios with different Affinity groups
   Scenario: 1 - User logins as organisation user and standard role
     Given Assistant User logs in to register for Pillar2
     Then I should be on Assistant role KB page
-    And The Heading should be Sorry, you’re unable to use this service
-    And The Body content should be You’ve signed in with a standard organisation account.
-    And The Body content should be Only Government Gateway accounts with an administrator role can register to use this service.
-    And The Body content should be You need to find someone with an administrator’s Government Gateway user ID who can register and then give you authority to report and manage Pillar 2 Top-up Taxes.
     When I click Find out more about who can use this service link
     Then I should navigate to guidance page
     When I click the browser back button

--- a/src/test/resources/features/EligiblityQuestionsPage.feature
+++ b/src/test/resources/features/EligiblityQuestionsPage.feature
@@ -41,11 +41,6 @@ Feature: Eligibility Questions for Pillar 2
     Given I am on UPE EQ Page
     When I choose No and continue
     Then I should navigate to NFM EQ page
-    And The caption should be Check if you need to report Pillar 2 Top-up Taxes
-    And The Heading should be Are you registering as the group’s nominated filing member?
-    And The Body content should be The nominated filing member is responsible for managing the group’s Pillar 2 Top-up Taxes returns and keeping business records.
-    When I continue without selecting an option
-    Then I should see error message Select yes if you are registering as the group’s nominated filing member on the Eligibility question Page
     When I choose Eligibility No NFM and continue
     Then I should navigate to NFM guidance page
     And The Heading should be Based on your answers, you cannot register this group to report Pillar 2 Top-up Taxes

--- a/src/test/resources/features/NFMNoIDFlowPages.feature
+++ b/src/test/resources/features/NFMNoIDFlowPages.feature
@@ -18,8 +18,6 @@ Feature: NFM NO ID journey
     And The Heading should be Is the nominated filing member registered in the UK?
     When I select option No and continue to next
     Then I should navigate to NFM Name page
-    And The caption must be Group details
-    And The Heading should be What is the name of the nominated filing member?
     When I enter NFM name as Test CYA
     Then I should navigate to NFM Address page
     When I enter Address as:
@@ -122,7 +120,6 @@ Feature: NFM NO ID journey
     Then I should navigate to NFM Name page
     When I enter NFM name as Test nfmName
     Then I should navigate to NFM Address page
-    And the page title should be What is the registered office address? - Report Pillar 2 Top-up Taxes - GOV.UK
     When I enter Address Line 1 as Test Address Line 1
     And I enter Address Line 2 as Test Address Line 2
     And I enter Region as Region

--- a/src/test/resources/features/NewDashboard/ContactDetailsAndRegistration.feature
+++ b/src/test/resources/features/NewDashboard/ContactDetailsAndRegistration.feature
@@ -433,12 +433,8 @@ Feature: Contact details for the filing member
     And I click on Save&Continue button
     Then I should be redirect to Registration processing page
     Then I should navigate to Registration confirmation page
-#    And The Body content should be Test Example Company Name has successfully registered to report for Domestic Top-up Tax
     And I click the browser back button
     Then I should navigate to Registration return error page
-    And The Heading should be You cannot return, your registration is complete
-#    And The Body content should be You have successfully registered to report Pillar 2 Top-up Taxes.
-#    And The Body content should be You can now report and manage your Pillar 2 Top-up Taxes.
     And I click report and manage your Pillar 2 Top-up Taxes. link
     And I should be on Dashboard page
     And I click the browser back button

--- a/src/test/resources/features/NewDashboard/DashboardPage.feature
+++ b/src/test/resources/features/NewDashboard/DashboardPage.feature
@@ -13,19 +13,6 @@ Feature: Dashboard Page
 #    And  I should be on Draft guidance page
 #    Then I close new tab
 #    And I should navigate back to main tab
-    And I should be on Dashboard page
-    And I should see User details in dashboard page
-    And I should see user details row 1 key ID:
-    And I should see user details row 2 key Registration date:
-    And I should see user details row 1 key Group:
-    And I should see the heading 2 on Dashboard page as Payments
-#    And The Body content should be You have no payments due
-#    And The Body content should be Make a payment
-    And I should see the heading 3 on Dashboard page as Manage account
-#    And The Body content should be View and amend contact details
-#    And The Body content should be View and amend group details
-#    And The Body content should be HMRC are currently delivering this service on a phased approach. We’ll release the tools that you need to submit your returns before the due date for reporting.
-#    And The Body content should be Refer to the Pillar 2 Top-up Taxes manual (opens in new tab) for more details.
     When I click View outstanding payments link
     Then I should navigate to under construction page
 #    And The Body content should be Your unique payment reference is XMPLR0012345674. You must use this when making Pillar 2 Top-up Taxes payments.

--- a/src/test/resources/features/P2IDValidationPage.feature
+++ b/src/test/resources/features/P2IDValidationPage.feature
@@ -13,10 +13,6 @@ Feature: BTA user registration for Pillar 2 service
     Then I should see error message Select yes if you have a Pillar 2 Top-up Taxes ID on the BTA Pillar2 validation Page
     When I select option No and continue to next
     Then I should navigate to bta register guidance page
-    And The Heading should be You need a Pillar 2 Top-up Taxes ID to access this service
-    And The Body content should be Register to report Pillar 2 Top-up Taxes to get a Pillar 2 Top-up Taxes ID.
-    And I should see Find out how to register to report Pillar 2 Top-up Taxes (opens in new tab) link
-    And I should see return to BTA button
     When I click Find out how to register to report Pillar 2 Top-up Taxes (opens in new tab) link
     Then I should be redirected to guidance page in a new tab
 

--- a/src/test/resources/features/RFMGRSflowPages.feature
+++ b/src/test/resources/features/RFMGRSflowPages.feature
@@ -128,7 +128,6 @@ Feature: RFM Ultimate Parent Entity and New nominated Filling Member GRS journey
     When registration is unsuccessful with party type mismatch error
     And I click on Save&Continue button
     Then I should be on RFM GRS Registration Mismatch Error Page
-    And The Heading should be The details you entered did not match our records
     When I click go back to select the entity type link
     Then I should be on RFM UK based entity type page
     When I select option Limited liability partnership and continue to GRS page
@@ -155,7 +154,6 @@ Feature: RFM Ultimate Parent Entity and New nominated Filling Member GRS journey
     When registration is unsuccessful with identifiers not match error
     And I click on Save&Continue button
     Then I should be on RFM GRS Registration Not Called Error Page
-    And The Heading should be Sorry, there is a problem with the service
     When I click Go back to select the entity type link
     Then I should be on RFM UK based entity type page
     When I select option Entity type not listed and continue to Name page

--- a/src/test/resources/features/RFMStartPage&KBValidations.feature
+++ b/src/test/resources/features/RFMStartPage&KBValidations.feature
@@ -44,9 +44,6 @@ Feature: RFM Start page
   Scenario: 3 - Verify Organisation Assistant User RFM KB page
     Given Assistant User logs in with rfm URL to Pillar2
     Then I should be on Assistant User RFM KB Page
-    And The Heading should be Sorry, you’re unable to use this service
-    And The Body content should be You’ve signed in with a standard organisation account.
-    And The Body content should be Only Government Gateway accounts with an administrator role can replace their nominated filing member.
     When I click Find out more about who can use this service link
     Then I should be on RFM start page
     When I select back link

--- a/src/test/resources/features/RFMnfmNoIDFlow.feature
+++ b/src/test/resources/features/RFMnfmNoIDFlow.feature
@@ -7,13 +7,6 @@ Feature: RFM CYA - NFM No ID flow
   Scenario: 1 - Verify RFM journey for NFM No Id flow until check your answers page and validate that previously entered data is pre populated
     Given Organisation User logs in with rfm URL to Pillar2
     And I access RFM start page
-    And The caption must be Replace filing member
-    And The Heading should be Replace the filing member for a Pillar 2 Top-up Taxes account
-    And I should see 4 sections on RFM start page
-    And I should see the section 1 as Tell HMRC when you have replaced your filing member
-    And I should see the section 3 as Obligations as the filing member
-    And I should see the section 4 as What you will need
-    And I should see register to report Pillar 2 Top-up Taxes link
     And I click on Continue button
     When I provide RFM pillar2 id as XMPLR0123456789
     When I enter registration date as:
@@ -30,10 +23,6 @@ Feature: RFM CYA - NFM No ID flow
     Then I should see an error message Select if you are the Ultimate Parent Entity or a new nominated filing member on the RFM journey error Page
     When I select corp position as NFM
     Then I should be on New NFM guidance page
-    And The caption must be Group details
-    And The Heading should be We need to match the details of the new nominated filing member to HMRC records
-    And The Body content should be If the new filing member is registered in the UK, we will ask you for identifying information so we can best match it with our records.
-    And The Body content should be If the new filing member is registered outside of the UK or if they are not a listed entity type, we will ask you for identifying information so we can create a new HMRC record.
     When I click on Continue button
     Then I should be on RFM registered in UK page
     When I select option No and continue to next
@@ -52,15 +41,6 @@ Feature: RFM CYA - NFM No ID flow
     And I click on Country selected
     And I click on Continue button
     Then I should be on RFM No ID CYA Page
-    Then The caption must be Group details
-    And The Heading should be Check your answers
-    And I should see details as below:
-      | KEY     | VALUE              |
-      | Name    | Test CYA           |
-      | Address | Address Line 1 CYA |
-      | Address | City CYA           |
-      | Address | EH55WY             |
-      | Address | Australia          |
     When I click change link for RFM New NFM Name
     Then I should navigate to RFM New NFM Contact Name Change
     When I provide RFM New NFM Name as New NFM Name Change

--- a/src/test/resources/features/RepaymentJourneys.feature
+++ b/src/test/resources/features/RepaymentJourneys.feature
@@ -8,32 +8,6 @@ Feature: Repayment Journey
     Given Organisation User logs in with existing entity group HMRC-PILLAR2-ORG, PLRID and XMPLR0012345674 for Pillar2 service
     Then I should be on Dashboard page
     And I access Non UK payment page
-    And The Heading should be Bank account details
-    When I click on Continue button
-    Then I should see bank account error message Enter the name of the bank on the Name of the Bank Element
-    And I should see bank account error message Enter the name on the account on the Account Name Element
-    And I should see bank account error message Enter the BIC or SWIFT code on the Swift Code Element
-    And I should see bank account error message Enter the IBAN on the Iban Element
-    When I refresh the page
-    When I enter Non UK Bank Account details as:
-      | KEY               | VALUE                  |
-      | bankName          | HSBC                   |
-      | nameOnBankAccount | HMRC Shipley           |
-      | bic               | HbuKGb4B               |
-      | iban              | gb29NWBK60161331926819 |
-    Then I should be on Repayment Contact Page
-    When I select back link
-    When I enter Non UK Bank Account details as:
-      | KEY               | VALUE                                                              |
-      | bankName          | NameOfTheBankMustBe40CharactersOrLessError                         |
-      | nameOnBankAccount | NameOnTheAccountMustBe60CharactersOrLessOrThereWillBeAnErrorAsSeen |
-      | bic               | HBUKG                                                              |
-      | iban              | 1Z03A1234567890ABCBBH1                                             |
-    Then I should see bank account error message Name of the bank must be 40 characters or less on the Name of the Bank Element
-    Then I should see bank account error message Name on the account must be 60 characters or less on the Account Name Element
-    Then I should see bank account error message BIC or SWIFT code must be between 8 and 11 characters long on the Swift Code Element
-    And I should see bank account error message Enter a valid IBAN like GB29NWBK60161331926819 on the Iban Element
-    When I refresh the page
     When I enter Non UK Bank Account details as:
       | KEY               | VALUE                                  |
       | bankName          | HSBC                                   |
@@ -49,26 +23,6 @@ Feature: Repayment Journey
     When I click Report Pillar 2 Top-up Taxes link
     Then I should be on Dashboard page
     And I click Sign out link
-    When Agent User logs in with existing entity group HMRC-AS-AGENT, AgentReference and 1234 for Pillar2 service
-    And I add delegated enrolment with HMRC-PILLAR2-ORG, PLRID, XMPLR0012345674 and pillar2-auth for Pillar2 service
-    Then I should be on ASA Pillar2 Input Page
-    And I provide ASA Pillar2 ID as XMPLR0012345674
-    And I click on Continue button
-    Then I should navigate to ASA Confirmation Page
-    And I click on Continue button
-    Then I should navigate to ASA Dashboard page
-    And I directly access Agent Non UK Payment Page page
-    When I enter Non UK Bank Account details as:
-      | KEY               | VALUE                                                              |
-      | nameOnBankAccount | NameOnTheAccountMustBe60CharactersOrLessOrThereWillBeAnErrorAsSeen |
-      | bic               | 0BCDEF01A1C                                                        |
-      | iban              | 1Z03A1234567890ABCBBH1                                             |
-    Then I should see bank account error message Enter the name of the bank on the Name of the Bank Element
-    And I should see bank account error message Name on the account must be 60 characters or less on the Account Name Element
-    And I should see bank account error message Enter a valid BIC or SWIFT code like HBUKGB4B on the Swift Code Element
-    And I should see bank account error message Enter a valid IBAN like GB29NWBK60161331926819 on the Iban Element
-    When I click Report Pillar 2 Top-up Taxes link
-    Then I should be on ASA Dashboard page
 
   @zap_accessibility @batch3
   Scenario: 2 - Organisation User navigates to repayment pages
@@ -142,19 +96,6 @@ Feature: Repayment Journey
     When  I click change link for Repayment Contact Telephone
     When I select option No and continue to next
     Then I should be on Repayment CYA Page
-    And I should see details as below:
-      | KEY                                              | VALUE                         |
-      | Refund amount                                    | £1000                         |
-      | Reason for refund request                        | Test Reason                   |
-      | What type of account will the refund be sent to? | Non-UK bank account           |
-      | Name of the bank                                 | HSBC2                         |
-      | Name on account                                  | Test Name2                    |
-      | BIC or SWIFT code                                | HBUKGB4C                      |
-      | IBAN                                             | GB29NWBK60161331926820        |
-      | Contact name                                     | Repayment Contact Name change |
-      | Email address                                    | email@change.com              |
-      | Can we contact by telephone?                     | No                            |
-    And I can see Print this page link
     When I click change link for Repayment UK Bank Method
     And I click on Continue button
     Then I should be on Repayment CYA Page

--- a/src/test/resources/features/UPEAndNFMGRSFlowPages.feature
+++ b/src/test/resources/features/UPEAndNFMGRSFlowPages.feature
@@ -90,13 +90,6 @@ Feature: Ultimate parent entity and Nominated Filling Member GRS journey
     When registration is unsuccessful with party type mismatch error
     And I click on Save&Continue button
     Then I should be on UPE registration failed error page
-    And The Heading should be The details you entered did not match our records
-    And The second heading should be How to confirm your details
-    And The Body content should be We could not match the details you entered with records held by HMRC.
-    And The Body content should be You can confirm your details with the records held by HMRC by:
-    And The Body content should be You can go back to select the entity type and try again using different details if you think you made an error when entering them.
-    And The Body content should be search Companies House for the company registration number and registered office address (opens in a new tab)
-    And The Body content should be ask for a copy of your Corporation Tax Unique Taxpayer Reference (opens in a new tab)
     When I click go back to select the entity type link
     Then I should be on UPE entity type page
     When I select back link
@@ -128,13 +121,6 @@ Feature: Ultimate parent entity and Nominated Filling Member GRS journey
     When registration is unsuccessful with party type mismatch error
     And I click on Save&Continue button
     Then I should be on NFM registration failed error page
-    And The Heading should be The details you entered did not match our records
-    And The second heading should be How to confirm your details
-    And The Body content should be We could not match the details you entered with records held by HMRC.
-    And The Body content should be You can confirm your details with the records held by HMRC by:
-    And The Body content should be You can go back to select the entity type and try again using different details if you think you made an error when entering them.
-    And The Body content should be search Companies House for the company registration number and registered office address (opens in a new tab)
-    And The Body content should be ask for a copy of your Corporation Tax Unique Taxpayer Reference (opens in a new tab)
     When I click go back to select the entity type link
     Then I should be on NFM entity type page
     When I select back link

--- a/src/test/resources/features/UPENoIDFLowPage.feature
+++ b/src/test/resources/features/UPENoIDFLowPage.feature
@@ -150,10 +150,6 @@ Feature: UPE NO ID journey
     Then I should see error message Select yes if the Ultimate Parent Entity is registered in the UK on the UPE business EQ Page
     When I select option No and continue to next
     Then I should navigate to input-upe-name page
-    When I click on Continue button
-    Then I should see error message You need to enter the name of the Ultimate Parent Entity on the Input UPE Name Page
-    When I enter UPE name as UPE Name character length Error validation and Maximum UPE character length should be entered 105 characters.
-    Then I should see error message Name of the Ultimate Parent Entity must be 105 characters or less on the Input UPE Name Page
     When I enter UPE name as Test upeName
     Then I should navigate to input-upe-address page
     When I enter Address as:


### PR DESCRIPTION
Content checks have been removed from files that are already being tested in the following unit tests:

AmendApiFailureViewSpec
BankAccountDetailsViewSpec
CannotReturnAfterSubscriptionViewSpec
CheckNewFilingMemberViewSpec
DashboardViewSpec
NfmNameRegistrationViewSpec
NfmRegisteredAddressViewSpec
NoPlrIdGuidanceViewSpec
RegisteringNfmForThisGroupViewSpec
RegistrationConfirmationViewSpec
RegistrationFailedNfmViewSpec
RegistrationFailedRfmViewSpec
RegistrationFailedUpeViewSpec
RepaymentsCheckYourAnswersViewSpec
RfmCheckYourAnswersViewSpec
StandardOrganisationViewSpec
StartPageViewSpec
UpeNameRegistrationViewSpec